### PR TITLE
README: fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Voronoi noise, packed for glslify
 usage: 
 ```glsl
 precision mediump float;
-#pragma glslify: fbm3d = require('glsl-voronoi-noise/3d')
+#pragma glslify: voronoi3d = require('glsl-voronoi-noise/3d')
 
 varying vec2 uv;
 uniform float t;
 
 void main() {
-    gl_FragColor.rgb = voronoi3d(vec3(uv, t);  
+    gl_FragColor.rgb = voronoi3d(vec3(uv, t));  
     gl_FragColor.a   = 1.0;
 }
 ```


### PR DESCRIPTION
This PR fixes the example code in the README. There was a missing closing paren and the glslify pragma had the wrong name.

Cheers